### PR TITLE
Fix Skip.testAll does run tests

### DIFF
--- a/__tests__/runner_test.ml
+++ b/__tests__/runner_test.ml
@@ -46,7 +46,8 @@ let () =
     Js.String.length input == 3);
   testAll "testAll - tuples" [("foo", 3); ("barbaz", 6); ("bananas!", 8)] (fun (input, output) ->
     Js.String.length input == output);
-  
+
+  Skip.testAll "testAll - expect fail" ["foo"; "bar"; "baz"] (fun _ -> false);
 
   describe "describe" (fun () ->
     test "some aspect" (fun () ->

--- a/src/jest.ml
+++ b/src/jest.ml
@@ -243,7 +243,11 @@ module Runner (A : Asserter) = struct
   end
 
   module Skip = struct
-    external test : string -> (unit -> 'a A.t) -> unit = "it.skip" [@@bs.val]
+    external _test : string -> (unit -> unit Js.undefined) -> unit = "it.skip" [@@bs.val]
+    let test name callback =
+      _test name (fun () -> 
+        affirm @@ callback ();
+        Js.undefined)
     external testAsync : string -> (('a A.t -> unit) -> unit) -> unit = "it.skip" [@@bs.val]
     let testAsync name ?timeout:_ callback =
       testAsync name callback


### PR DESCRIPTION
This PR fixes `Skip.testAll` so that it actually skips tests.