### PR TITLE
fix afterAllPromise not resolving

### DIFF
--- a/src/jest.ml
+++ b/src/jest.ml
@@ -191,7 +191,7 @@ module Runner (A : Asserter) = struct
     afterAllAsync
       (fun finish -> callback (fun () -> finish ()); Js.undefined)
       (Js.Undefined.fromOption timeout)
-  external afterAllPromise : (unit -> 'a Js.Promise.t) -> int Js.Undefined.t -> unit = "afterAll" [@@bs.val]
+  external afterAllPromise : (unit -> 'a Js.Promise.t [@bs.uncurry]) -> int Js.Undefined.t -> unit = "afterAll" [@@bs.val]
   let afterAllPromise ?timeout callback =
     afterAllPromise
       (fun () -> callback () |> Js.Promise.resolve)


### PR DESCRIPTION
Looks like [@bs.uncurry] was added to all the other xPromise calls here: https://github.com/glennsl/bs-jest/commit/d67564ea4c488b9eb6604b6dca484798c466b813, but afterAllPromise was missed. Not sure why this doesn't cause the tests to fail, I had a quick experiment - but it was causing things to get stuck in my test suite.

If you understand why the bs-jest tests for `afterAllPromise` work please let me know - trying to get my head round it :-)