### PR TITLE
Add advanceTimersByTime.

### DIFF
--- a/__tests__/jest_test.ml
+++ b/__tests__/jest_test.ml
@@ -50,6 +50,18 @@ describe "Fake Timers" (fun () ->
     
     expect (before, inbetween, !flag) = (false, false, true)
   );
+
+  test "advanceTimersByTime" (fun () ->
+    let flag = ref false in
+    Jest.useFakeTimers ();
+    setTimeout(fun () -> flag := true) 1500;
+    let before = !flag in
+    Jest.advanceTimersByTime 1000;
+    let inbetween = !flag in
+    Jest.advanceTimersByTime 1000;
+    
+    expect (before, inbetween, !flag) = (false, false, true)
+  );
   
   test "runOnlyPendingTimers" (fun () ->
     let count = ref 0 in

--- a/src/jest.ml
+++ b/src/jest.ml
@@ -429,6 +429,7 @@ module Jest = struct
   external runAllTimers : unit -> unit = "jest.runAllTimers" [@@bs.val]
   external runAllImmediates : unit -> unit = "jest.runAllImmediates" [@@bs.val]
   external runTimersToTime : int -> unit = "jest.runTimersToTime" [@@bs.val]
+  external advanceTimersByTime : int -> unit = "jest.advanceTimersByTime" [@@bs.val]
   external runOnlyPendingTimers : unit -> unit = "jest.runOnlyPendingTimers" [@@bs.val]
   external useFakeTimers : unit -> unit = "jest.useFakeTimers" [@@bs.val]
   external useRealTimers : unit -> unit = "jest.useRealTimers" [@@bs.val]

--- a/src/jest.mli
+++ b/src/jest.mli
@@ -173,6 +173,7 @@ module Jest : sig
   external runAllTimers : unit -> unit = "jest.runAllTimers" [@@bs.val]
   external runAllImmediates : unit -> unit = "jest.runAllImmediates" [@@bs.val]
   external runTimersToTime : int -> unit = "jest.runTimersToTime" [@@bs.val]
+  external advanceTimersByTime : int -> unit = "jest.advanceTimersByTime" [@@bs.val]
   external runOnlyPendingTimers : unit -> unit = "jest.runOnlyPendingTimers" [@@bs.val]
   external useFakeTimers : unit -> unit = "jest.useFakeTimers" [@@bs.val]
   external useRealTimers : unit -> unit = "jest.useRealTimers" [@@bs.val]


### PR DESCRIPTION
`runAllTimersToTime` was renamed to `advanceTimersByTime` in Jest 22.0.0+: https://jestjs.io/docs/en/jest-object#jestadvancetimersbytimemstorun. This PR adds a binding for `advanceTimersByTime` to make it accessible on the `Jest` module in `bs-jest`. cc/ @glennsl 