### PR TITLE
Upgrade bs-platform to 5.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -866,9 +866,9 @@
       }
     },
     "bs-platform": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-4.0.18.tgz",
-      "integrity": "sha512-BwzW0iYHvREqUZIgQxJmdJrxexppLvJxYQ4LLexbhCp7uZU5DIZ5ub4ZHpkCkc8fn8bsXWc+Rrejb3csi+BoAQ==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-5.0.4.tgz",
+      "integrity": "sha512-rXM+ztN8wYXQ4ojfFGylvPOf8GRLOvM94QJsMMV9VpsLChKCjesWMNybTZvpoyNsESu2nC5q+C9soG+BPhuUFQ==",
       "dev": true
     },
     "bser": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "bsconfig.json"
   ],
   "devDependencies": {
-    "bs-platform": "^4.0.18",
+    "bs-platform": "^5.0.4",
     "coveralls": "^3.0.3",
     "nyc": "^13.3.0"
   },


### PR DESCRIPTION
All tests pass with 5.0.4, just as they did with 4.0.18. I'm just starting out with BS and I can't quite tell what's going on with the bs-platform versioning, so I'm not sure if this should accept `^4.0.18 || ^5.0.4` or something like that? I also have trivial PRs queued up for this same change on bs-json and bs-fetch, if you want them.